### PR TITLE
Kubernetes operators

### DIFF
--- a/kubernetes-operators/README.md
+++ b/kubernetes-operators/README.md
@@ -1,0 +1,76 @@
+# Выполнено ДЗ № 4
+
+ - [x] Основное ДЗ
+ - [ ] Задание со *
+
+## В процессе сделано:
+###CR, CRD и Validation
+Создан CustomResource deploy/cr.yaml.
+Применение заканчивается ошибкой:
+
+    kubectl apply -f deploy/cr.yml
+    error: the path "deploy/cr.yml" does not exist
+
+Ошибка связана с отсутствием объектов типа MySQL в API kubernetes.
+
+CustomResourceDefinition - это ресурс для определения других ресурсов (далее CRD).
+Создали CRD deploy/crd.yml, применяем:
+
+    kubectl apply -f deploy/crd.yml
+    Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
+    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created
+
+Создаем еще раз CR:
+
+    kubectl apply -f deploy/cr.yaml
+    mysql.otus.homework/mysql-instance created
+
+C созданными объектами можно взаимодействовать через kubectl:
+    
+    kubectl get crd
+    kubectl get mysqls.otus.homework
+    kubectl describe mysqls.otus.homework mysql-instance
+
+На данный момент мы никак не описали схему нашего CustomResource. Объекты типа mysql могут иметь абсолютно произвольные 
+поля, нам бы хотелось этого избежать, для этого будем использовать validation. Для начала удалим CR mysql-instance:
+
+    kubectl delete mysqls.otus.homework mysql-instance
+
+Добавлены validation параметры, применяем заново:
+
+    kubectl apply -f deploy/crd.yml
+    Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
+    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured
+    
+    kubectl apply -f deploy/cr.yaml
+    mysql.otus.homework/mysql-instance created
+
+Добавим дерективу spec.validation.spec.reqiored в CRD. Удалим CR поле с размером хранилища, запустим cr и crd:
+
+    kubectl apply -f deploy/crd.yml
+    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured
+    
+    kubectl apply -f deploy/cr.yml
+    The MySQL "mysql-instance" is invalid: spec.storage_size: Required value
+
+Данный ответ и ожидался.
+
+### Операторы
+Оператор включает в себя CustomResourceDefinition и сustom сontroller.
+
+CRD содержит описание объектов CR.
+
+Контроллер следит за объектами определенного типа, и осуществляет всю логику работы оператора
+
+Остановился на слайде 15
+
+## Как запустить проект:
+    minikube start
+
+Затем применить описанную выше последовательность действий
+
+## Как проверить работоспособность:
+Запустить проект и т.д.
+
+## PR checklist:
+ - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-operators/README.md
+++ b/kubernetes-operators/README.md
@@ -1,11 +1,11 @@
-# Выполнено ДЗ № 4
+# Выполнено ДЗ № 7
 
  - [x] Основное ДЗ
  - [ ] Задание со *
 
 ## В процессе сделано:
 ###CR, CRD и Validation
-Создан CustomResource deploy/cr.yaml.
+Создан CustomResource deploy/cr.yml.
 Применение заканчивается ошибкой:
 
     kubectl apply -f deploy/cr.yml
@@ -22,10 +22,10 @@ CustomResourceDefinition - это ресурс для определения д�
 
 Создаем еще раз CR:
 
-    kubectl apply -f deploy/cr.yaml
+    kubectl apply -f deploy/cr.yml
     mysql.otus.homework/mysql-instance created
 
-C созданными объектами можно взаимодействовать через kubectl:
+С созданными объектами можно взаимодействовать через kubectl:
     
     kubectl get crd
     kubectl get mysqls.otus.homework
@@ -42,10 +42,10 @@ C созданными объектами можно взаимодейство�
     Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
     customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured
     
-    kubectl apply -f deploy/cr.yaml
+    kubectl apply -f deploy/cr.yml
     mysql.otus.homework/mysql-instance created
 
-Добавим дерективу spec.validation.spec.reqiored в CRD. Удалим CR поле с размером хранилища, запустим cr и crd:
+Добавим директиву spec.validation.spec.required в CRD. Удалим CR поле с размером хранилища, запустим cr и crd:
 
     kubectl apply -f deploy/crd.yml
     customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured
@@ -62,7 +62,95 @@ CRD содержит описание объектов CR.
 
 Контроллер следит за объектами определенного типа, и осуществляет всю логику работы оператора
 
-Остановился на слайде 15
+Используемый/написанный нами контроллер будет обрабатывать два типа событий:
+1) При создании объекта типа (kind: mySQL), он будет:
+   
+
+    * Cоздавать PersistentVolume, PersistentVolumeClaim, Deployment, Service для mysql
+    * Создавать PersistentVolume, PersistentVolumeClaim для бэкапов базы данных, если их
+      еще нет.
+    * Пытаться восстановиться из бэкапа
+
+2) При удалении объекта типа (kind: mySQL), он будет:
+
+
+    * Удалять все успешно завершенные backup-job и restore-job
+    * Удалять PersistentVolume, PersistentVolumeClaim, Deployment, Service для mysql
+
+Часть с Python не делалась. Создадим и применим манифесты:
+
+
+    service-account.yml
+    role.yml
+    role-binding.yml
+    deploy-operator.yml
+
+    kubectl apply -f deploy\
+    mysql.otus.homework/mysql-instance unchanged
+    Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
+    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework unchanged
+    deployment.apps/mysql-operator created
+    clusterrolebinding.rbac.authorization.k8s.io/workshop-operator created
+    clusterrole.rbac.authorization.k8s.io/mysql-operator created
+    serviceaccount/mysql-operator created
+
+Проверяем что появились pvc:
+
+    kubectl get pvc
+    NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    backup-mysql-instance-pvc   Bound    pvc-7c7b05ae-46fa-45d3-a3b0-6071a8871b98   1Gi        RWO            standard       4m18s
+    mysql-instance-pvc          Bound    pvc-312c8512-48e2-4f18-9a1e-817562e863bf   1Gi        RWO            standard       4m18s
+
+Команда export не работает в Windows Powershell, поэтому придется немного переделать команды заполнения базы:
+
+    kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}"
+    mysql-instance-6785949c48-4m9kd
+
+    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -u root -potuspassword -e "CREATE TABLE test ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );" otus-database
+    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -potuspassword -e "INSERT INTO test ( id, name ) VALUES ( null, 'some data' );" otus-database
+    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -potuspassword -e "INSERT INTO test ( id, name ) VALUES ( null, 'some data-2' );" otus-database
+    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -potuspassword -e "select * from test;" otus-database
+
+    +----+-------------+
+    | id | name        |
+    +----+-------------+
+    |  1 | some data   |
+    |  2 | some data-2 |
+    +----+-------------+
+
+###Проверка работоспособности
+
+Удалим mysql-instance:
+
+    kubectl delete mysqls.otus.homework mysql-instance
+    mysql.otus.homework "mysql-instance" deleted
+
+Теперь kubectl get pv показывает, что PV для mysql больше нет, а kubectl get jobs.batch показывает:
+
+    NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                               STORAGECLASS   REASON   AGE
+    backup-mysql-instance-pv                   1Gi        RWO            Retain           Available                                                               14m
+    mysql-instance-pv                          1Gi        RWO            Retain           Available                                                               14m
+    pvc-7c7b05ae-46fa-45d3-a3b0-6071a8871b98   1Gi        RWO            Delete           Bound       default/backup-mysql-instance-pvc   standard                14m
+
+    NAME                         COMPLETIONS   DURATION   AGE
+    backup-mysql-instance-job    1/1           1s         61s
+    restore-mysql-instance-job   0/1           14m        14m
+
+
+Если Job не выполнилась или выполнилась с ошибкой, то ее нужно удалять в ручную, т к иногда полезно посмотреть логи.
+
+Создадим заново mysql-instance:
+
+    kubectl apply -f deploy/cr.yml 
+
+Ждем некоторое время, затем повторяем не особо удобные команды в Windows на получение имени пода и делаем SELECT запрос>:
+
+    +----+-------------+
+    | id | name        |
+    +----+-------------+
+    |  1 | some data   |
+    |  2 | some data-2 |
+    +----+-------------+
 
 ## Как запустить проект:
     minikube start
@@ -70,7 +158,7 @@ CRD содержит описание объектов CR.
 Затем применить описанную выше последовательность действий
 
 ## Как проверить работоспособность:
-Запустить проект и т.д.
+Запустить проект и выполнить описанную выше последовательность действий
 
 ## PR checklist:
  - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-operators/deploy/cr.yaml
+++ b/kubernetes-operators/deploy/cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword # Так делать не нужно, следует использовать secret
+  #storage_size: 1Gi

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -6,4 +6,4 @@ spec:
   image: mysql:5.7
   database: otus-database
   password: otuspassword # Так делать не нужно, следует использовать secret
-  #storage_size: 1Gi
+  storage_size: 1Gi

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework  # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced           # Данный CRD будер работать в рамках namespace
+  group: otus.homework        # Группа, отражается в поле apiVersion CR
+  versions:                   # Список версий
+    - name: v1
+      served: true            # Будет ли обслуживаться API-сервером данная версия
+      storage: true           # Версия описания, которая будет сохраняться в etcd
+  validation:                 # в v1 это, вроде как, schema - обязательный параметр
+    openAPIV3Schema:
+      type: object
+      required: ["spec"]
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+        spec:
+          type: object
+          required: ["image", "database", "password", "storage_size"]
+          properties:
+            image:
+              type: string
+            database:
+              type: string
+            password:
+              type: string
+            storage_size:
+              type: string
+  names:                      # различные форматы имени объекта CR
+    kind: MySQL               # kind CR
+    plural: mysqls
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -9,6 +9,12 @@ spec:
     - name: v1
       served: true            # Будет ли обслуживаться API-сервером данная версия
       storage: true           # Версия описания, которая будет сохраняться в etcd
+  names:                      # различные форматы имени объекта CR
+    kind: MySQL               # kind CR
+    plural: mysqls
+    singular: mysql
+    shortNames:
+      - ms
   validation:                 # в v1 это, вроде как, schema - обязательный параметр
     openAPIV3Schema:
       type: object
@@ -35,9 +41,4 @@ spec:
               type: string
             storage_size:
               type: string
-  names:                      # различные форматы имени объекта CR
-    kind: MySQL               # kind CR
-    plural: mysqls
-    singular: mysql
-    shortNames:
-      - ms
+

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "zhenkins/mysql-operator:v0.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+  - kind: ServiceAccount
+    name: mysql-operator
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ № 7

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
###CR, CRD и Validation
Создан CustomResource deploy/cr.yml.
Применение заканчивается ошибкой:

    kubectl apply -f deploy/cr.yml
    error: the path "deploy/cr.yml" does not exist

Ошибка связана с отсутствием объектов типа MySQL в API kubernetes.

CustomResourceDefinition - это ресурс для определения других ресурсов (далее CRD).
Создали CRD deploy/crd.yml, применяем:

    kubectl apply -f deploy/crd.yml
    Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created

Создаем еще раз CR:

    kubectl apply -f deploy/cr.yml
    mysql.otus.homework/mysql-instance created

С созданными объектами можно взаимодействовать через kubectl:
    
    kubectl get crd
    kubectl get mysqls.otus.homework
    kubectl describe mysqls.otus.homework mysql-instance

На данный момент мы никак не описали схему нашего CustomResource. Объекты типа mysql могут иметь абсолютно произвольные 
поля, нам бы хотелось этого избежать, для этого будем использовать validation. Для начала удалим CR mysql-instance:

    kubectl delete mysqls.otus.homework mysql-instance

Добавлены validation параметры, применяем заново:

    kubectl apply -f deploy/crd.yml
    Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured
    
    kubectl apply -f deploy/cr.yml
    mysql.otus.homework/mysql-instance created

Добавим директиву spec.validation.spec.required в CRD. Удалим CR поле с размером хранилища, запустим cr и crd:

    kubectl apply -f deploy/crd.yml
    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework configured
    
    kubectl apply -f deploy/cr.yml
    The MySQL "mysql-instance" is invalid: spec.storage_size: Required value

Данный ответ и ожидался.

### Операторы
Оператор включает в себя CustomResourceDefinition и сustom сontroller.

CRD содержит описание объектов CR.

Контроллер следит за объектами определенного типа, и осуществляет всю логику работы оператора

Используемый/написанный нами контроллер будет обрабатывать два типа событий:
1) При создании объекта типа (kind: mySQL), он будет:
   

    * Cоздавать PersistentVolume, PersistentVolumeClaim, Deployment, Service для mysql
    * Создавать PersistentVolume, PersistentVolumeClaim для бэкапов базы данных, если их
      еще нет.
    * Пытаться восстановиться из бэкапа

2) При удалении объекта типа (kind: mySQL), он будет:


    * Удалять все успешно завершенные backup-job и restore-job
    * Удалять PersistentVolume, PersistentVolumeClaim, Deployment, Service для mysql

Часть с Python не делалась. Создадим и применим манифесты:


    service-account.yml
    role.yml
    role-binding.yml
    deploy-operator.yml

    kubectl apply -f deploy\
    mysql.otus.homework/mysql-instance unchanged
    Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
    customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework unchanged
    deployment.apps/mysql-operator created
    clusterrolebinding.rbac.authorization.k8s.io/workshop-operator created
    clusterrole.rbac.authorization.k8s.io/mysql-operator created
    serviceaccount/mysql-operator created

Проверяем что появились pvc:

    kubectl get pvc
    NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    backup-mysql-instance-pvc   Bound    pvc-7c7b05ae-46fa-45d3-a3b0-6071a8871b98   1Gi        RWO            standard       4m18s
    mysql-instance-pvc          Bound    pvc-312c8512-48e2-4f18-9a1e-817562e863bf   1Gi        RWO            standard       4m18s

Команда export не работает в Windows Powershell, поэтому придется немного переделать команды заполнения базы:

    kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}"
    mysql-instance-6785949c48-4m9kd

    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -u root -potuspassword -e "CREATE TABLE test ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );" otus-database
    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -potuspassword -e "INSERT INTO test ( id, name ) VALUES ( null, 'some data' );" otus-database
    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -potuspassword -e "INSERT INTO test ( id, name ) VALUES ( null, 'some data-2' );" otus-database
    kubectl exec -it mysql-instance-6785949c48-4m9kd -- mysql -potuspassword -e "select * from test;" otus-database

    +----+-------------+
    | id | name        |
    +----+-------------+
    |  1 | some data   |
    |  2 | some data-2 |
    +----+-------------+

###Проверка работоспособности

Удалим mysql-instance:

    kubectl delete mysqls.otus.homework mysql-instance
    mysql.otus.homework "mysql-instance" deleted

Теперь kubectl get pv показывает, что PV для mysql больше нет, а kubectl get jobs.batch показывает:

    NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                               STORAGECLASS   REASON   AGE
    backup-mysql-instance-pv                   1Gi        RWO            Retain           Available                                                               14m
    mysql-instance-pv                          1Gi        RWO            Retain           Available                                                               14m
    pvc-7c7b05ae-46fa-45d3-a3b0-6071a8871b98   1Gi        RWO            Delete           Bound       default/backup-mysql-instance-pvc   standard                14m

    NAME                         COMPLETIONS   DURATION   AGE
    backup-mysql-instance-job    1/1           1s         61s
    restore-mysql-instance-job   0/1           14m        14m


Если Job не выполнилась или выполнилась с ошибкой, то ее нужно удалять в ручную, т к иногда полезно посмотреть логи.

Создадим заново mysql-instance:

    kubectl apply -f deploy/cr.yml 

Ждем некоторое время, затем повторяем не особо удобные команды в Windows на получение имени пода и делаем SELECT запрос>:

    +----+-------------+
    | id | name        |
    +----+-------------+
    |  1 | some data   |
    |  2 | some data-2 |
    +----+-------------+

## Как запустить проект:
    minikube start

Затем применить описанную выше последовательность действий

## Как проверить работоспособность:
Запустить проект и выполнить описанную выше последовательность действий

## PR checklist:
 - [x] Выставлен label с темой домашнего задания